### PR TITLE
refactor(helm): allow renovate maintenance 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,21 +6,21 @@ include:
     file: /base_register_stage.yml
     ref: v9.1.1
   #
-  - /azure-db/.gitlab-ci.yml
-  - /bats/.gitlab-ci.yml
-  - /curl/.gitlab-ci.yml
-  - /fluentd-modsecurity/.gitlab-ci.yml
-  - /git-deploy/.gitlab-ci.yml
-  - /git-tag-release/.gitlab-ci.yml
+  # - /azure-db/.gitlab-ci.yml
+  # - /bats/.gitlab-ci.yml
+  # - /curl/.gitlab-ci.yml
+  # - /fluentd-modsecurity/.gitlab-ci.yml
+  # - /git-deploy/.gitlab-ci.yml
+  # - /git-tag-release/.gitlab-ci.yml
   - /helm/.gitlab-ci.yml
-  - /infra-ansible-ci/.gitlab-ci.yml
-  - /k8s-ns-killer/.gitlab-ci.yml
-  - /k8s-object-cleaner/.gitlab-ci.yml
-  - /kubectl/.gitlab-ci.yml
-  - /nginx4spa/.gitlab-ci.yml
-  - /pg-cleaner/.gitlab-ci.yml
-  - /puppeteer/.gitlab-ci.yml
-  - /wait-for-postgres/.gitlab-ci.yml
+  # - /infra-ansible-ci/.gitlab-ci.yml
+  # - /k8s-ns-killer/.gitlab-ci.yml
+  # - /k8s-object-cleaner/.gitlab-ci.yml
+  # - /kubectl/.gitlab-ci.yml
+  # - /nginx4spa/.gitlab-ci.yml
+  # - /pg-cleaner/.gitlab-ci.yml
+  # - /puppeteer/.gitlab-ci.yml
+  # - /wait-for-postgres/.gitlab-ci.yml
 
 #
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,21 +6,21 @@ include:
     file: /base_register_stage.yml
     ref: v9.1.1
   #
-  # - /azure-db/.gitlab-ci.yml
-  # - /bats/.gitlab-ci.yml
-  # - /curl/.gitlab-ci.yml
-  # - /fluentd-modsecurity/.gitlab-ci.yml
-  # - /git-deploy/.gitlab-ci.yml
-  # - /git-tag-release/.gitlab-ci.yml
+  - /azure-db/.gitlab-ci.yml
+  - /bats/.gitlab-ci.yml
+  - /curl/.gitlab-ci.yml
+  - /fluentd-modsecurity/.gitlab-ci.yml
+  - /git-deploy/.gitlab-ci.yml
+  - /git-tag-release/.gitlab-ci.yml
   - /helm/.gitlab-ci.yml
-  # - /infra-ansible-ci/.gitlab-ci.yml
-  # - /k8s-ns-killer/.gitlab-ci.yml
-  # - /k8s-object-cleaner/.gitlab-ci.yml
-  # - /kubectl/.gitlab-ci.yml
-  # - /nginx4spa/.gitlab-ci.yml
-  # - /pg-cleaner/.gitlab-ci.yml
-  # - /puppeteer/.gitlab-ci.yml
-  # - /wait-for-postgres/.gitlab-ci.yml
+  - /infra-ansible-ci/.gitlab-ci.yml
+  - /k8s-ns-killer/.gitlab-ci.yml
+  - /k8s-object-cleaner/.gitlab-ci.yml
+  - /kubectl/.gitlab-ci.yml
+  - /nginx4spa/.gitlab-ci.yml
+  - /pg-cleaner/.gitlab-ci.yml
+  - /puppeteer/.gitlab-ci.yml
+  - /wait-for-postgres/.gitlab-ci.yml
 
 #
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,16 @@ $ mkdir foo
 
 1. Include this local `.gitlab-ci.yml` in the includes of [the root `.gitlab-ci.yml`](./.gitlab-ci.yml).
 
+## Test
+
+### Lint Dockerfiles
+
+```sh
+$ docker run --rm -i hadolint/hadolint < ./<image>/Dockerfile
+# example
+$ docker run --rm -i hadolint/hadolint < ./helm/Dockerfile
+```
+
 ## Release policy
 
 ### One click semantic release !

--- a/bats/.gitlab-ci.yml
+++ b/bats/.gitlab-ci.yml
@@ -24,6 +24,8 @@ Test bats:
     - bats --version
     - bats /opt/bats/test
     - bats /usr/lib/bats-assert/test
+    # - bats /usr/lib/bats-file/test
+    - bats /usr/lib/bats-support/test
     - bats ./bats/test
 
 Publish bats to Github Registry:

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -20,12 +20,10 @@ Build helm:
         jq '.dependencies["@socialgouv/helm-charts"]' |
         grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
       )
-    - echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}"
+    - DOCKER_BUILD_ARGS="--build-arg HELM_CHART_VERSION=${HELM_CHART_VERSION}"
   variables:
     CONTEXT: helm
     IMAGE_NAME: ${CI_REGISTRY_IMAGE}/helm
-    DOCKER_BUILD_ARGS: >-
-      --build-arg HELM_CHART_VERSION=${HELM_CHART_VERSION}
 
 Test helm:
   stage: "Test"

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -16,7 +16,7 @@ Build helm:
     # The script below allow will build the version present in that file.
     - apk add --no-cache jq
     - export HELM_CHART_VERSION=$(
-        cat /app/helm/package.json |
+        cat ./helm/package.json |
         jq '.dependencies["@socialgouv/helm-charts"]' |
         grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
       )

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -20,6 +20,7 @@ Build helm:
         jq '.dependencies["@socialgouv/helm-charts"]' |
         grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
       )
+    - echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}"
   variables:
     CONTEXT: helm
     IMAGE_NAME: ${CI_REGISTRY_IMAGE}/helm

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -9,9 +9,22 @@ Build helm:
   needs:
     - Lint helm
   extends: .base_register_to_gitlab_stage
+  before_script:
+    # NODE(douglasduteil): build from renovate maintaining package.json
+    # To allow renovate to maintaining the socialgouv/docker/helm image
+    # we use a fake `package.json` that link to the repo we need to follow.
+    # The script below allow will build the version present in that file.
+    - apk add --no-cache jq
+    - export HELM_CHART_VERSION=$(
+        cat /app/helm/package.json |
+        jq '.dependencies["@socialgouv/helm-charts"]' |
+        grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
+      )
   variables:
     CONTEXT: helm
     IMAGE_NAME: ${CI_REGISTRY_IMAGE}/helm
+    DOCKER_BUILD_ARGS: >-
+      --build-arg HELM_CHART_VERSION=${HELM_CHART_VERSION}
 
 Test helm:
   stage: "Test"
@@ -26,6 +39,12 @@ Test helm:
     - kubectl version
     #
     - helm list
+    #
+    # Test that we can fetch the latest version
+    #
+    - echo "https://github.com/SocialGouv/helm-charts/releases/tag/#${HELM_CHART_VERSION}"
+    - helm just fetch "socialgouv/app#${HELM_CHART_VERSION}"
+    - test -d ./.chart
 
 Publish helm to Github Registry:
   extends: .base_publish_to_github_stage

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -18,7 +18,7 @@ Build helm:
     - HELM_CHART_VERSION=$(
         cat ./helm/package.json |
         jq '.dependencies["@socialgouv/helm-charts"]' |
-        grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
+        grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+'
       )
     - DOCKER_BUILD_ARGS="--build-arg HELM_CHART_VERSION=${HELM_CHART_VERSION}"
   variables:

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -46,7 +46,7 @@ Test helm:
     - test -d ./.charts
     - test -d ./.charts/app
     - test -f ./.charts/app/Chart.yaml
-    - "grep 'version: ${HELM_CHART_VERSION}' ./.charts/app/Chart.yaml"
+    - "grep 'version: '${HELM_CHART_VERSION} ./.charts/app/Chart.yaml"
 
 Publish helm to Github Registry:
   extends: .base_publish_to_github_stage

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -44,7 +44,10 @@ Test helm:
     #
     - echo "https://github.com/SocialGouv/helm-charts/releases/tag/#${HELM_CHART_VERSION}"
     - helm just fetch "socialgouv/app#${HELM_CHART_VERSION}"
-    - test -d ./.chart
+    - test -d ./.charts
+    - test -d ./.charts/app
+    - test -d ./.charts/app/Chart.yaml
+    - "grep 'version: ${HELM_CHART_VERSION}' ./.charts/app/Chart.yaml"
 
 Publish helm to Github Registry:
   extends: .base_publish_to_github_stage

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -41,11 +41,11 @@ Test helm:
     #
     # Test that we can fetch the latest version
     #
-    - echo "https://github.com/SocialGouv/helm-charts/releases/tag/#${HELM_CHART_VERSION}"
+    - echo "https://github.com/SocialGouv/helm-charts/releases/tag/v${HELM_CHART_VERSION}"
     - helm just fetch "socialgouv/app#${HELM_CHART_VERSION}"
     - test -d ./.charts
     - test -d ./.charts/app
-    - test -d ./.charts/app/Chart.yaml
+    - test -f ./.charts/app/Chart.yaml
     - "grep 'version: ${HELM_CHART_VERSION}' ./.charts/app/Chart.yaml"
 
 Publish helm to Github Registry:

--- a/helm/.gitlab-ci.yml
+++ b/helm/.gitlab-ci.yml
@@ -15,7 +15,7 @@ Build helm:
     # we use a fake `package.json` that link to the repo we need to follow.
     # The script below allow will build the version present in that file.
     - apk add --no-cache jq
-    - export HELM_CHART_VERSION=$(
+    - HELM_CHART_VERSION=$(
         cat ./helm/package.json |
         jq '.dependencies["@socialgouv/helm-charts"]' |
         grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -12,11 +12,17 @@ COPY --from=bats-image /usr/lib/bats-assert /usr/lib/bats-assert
 COPY --from=bats-image /usr/lib/bats-support /usr/lib/bats-support
 COPY --from=bats-image /usr/lib/bats-file /usr/lib/bats-file
 
-# ## Install envsubst & coreutils
-RUN apk add --update --no-cache \
-  bash=~5 \
-  bats=~1 \
-  coreutils=~8 \
-  ;
+ARG HELM_CHART_VERSION
+ENV HELM_CHART_VERSION
 
-RUN helm init --client-only
+RUN set -ex \
+  #
+  && apk add --update --no-cache \
+    bash=~5 \
+    bats=~1 \
+    coreutils=~8 \
+  #
+  && helm init --client-only \
+  && helm repo add socialgouv https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION} \
+  && wget -qO - https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz | tar -C $(helm home) -xzv \
+  ;

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -24,8 +24,8 @@ RUN set -ex \
     coreutils=~8 \
   #
   && helm init --client-only \
-  && helm repo add socialgouv "https://github.com/SocialGouv/helm-charts/releases/download/${HELM_CHART_VERSION}" \
+  && helm repo add socialgouv "https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}" \
   && wget -qO - \
-    "https://github.com/SocialGouv/helm-charts/releases/download/${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz" \
+    "https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz" \
     | tar -C "$(helm home)" -xzv \
   ;

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,43 +1,22 @@
+#
 
-FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:0.29.0 AS kubectl-image
+FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:1.3.0 AS kubectl-image
+FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/bats:1.3.0 AS bats-image
+
+#
+
 FROM alpine/helm:2.14.3
 
-## Install envsubst & coreutils
+COPY --from=kubectl-image /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=bats-image /usr/lib/bats-assert /usr/lib/bats-assert
+COPY --from=bats-image /usr/lib/bats-support /usr/lib/bats-support
+COPY --from=bats-image /usr/lib/bats-file /usr/lib/bats-file
+
+# ## Install envsubst & coreutils
 RUN apk add --update --no-cache \
   bash=~5 \
   bats=~1 \
   coreutils=~8 \
-  curl=~7 \
-  gettext-dev=~0 \
-  git=~2 \
-  parallel=~20200222
+  ;
 
-ENV HOME=/config
-
-COPY --from=kubectl-image /usr/local/bin/kubectl /usr/local/bin/kubectl
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN set -x && \
-    adduser kubectl -Du 2342 -h /config && \
-    chgrp -R kubectl /usr/local; \
-    find /usr/local -type d -exec chmod g+w {} \; && \
-    echo "kubectl ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kubectl; \
-    chmod 0440 /etc/sudoers.d/kubectl; \
-    # Create non-root user (with a randomly chosen UID/GUI).
-    \
-    # Basic check it works.
-    kubectl version --client; \
-    \
-    #
-    # Install extra bats dependencies
-    \
-    git clone -b 'v0.3.0' --single-branch --depth 1 \
-      https://github.com/ztombol/bats-support /usr/lib/bats-support; \
-    git clone -b 'v0.3.0' --single-branch --depth 1 \
-      https://github.com/ztombol/bats-assert /usr/lib/bats-assert;
-
-
-USER kubectl
-
-ENTRYPOINT ["/usr/local/bin/kubectl"]
+RUN helm init --client-only

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=bats-image /usr/lib/bats-support /usr/lib/bats-support
 COPY --from=bats-image /usr/lib/bats-file /usr/lib/bats-file
 
 ARG HELM_CHART_VERSION
-ENV HELM_CHART_VERSION
+ENV HELM_CHART_VERSION=${HELM_CHART_VERSION}
 
 RUN set -ex \
   #

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -24,8 +24,8 @@ RUN set -ex \
     coreutils=~8 \
   #
   && helm init --client-only \
-  && helm repo add socialgouv "https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}" \
+  && helm repo add socialgouv "https://github.com/SocialGouv/helm-charts/releases/download/${HELM_CHART_VERSION}" \
   && wget -qO - \
-    "https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz" \
+    "https://github.com/SocialGouv/helm-charts/releases/download/${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz" \
     | tar -C "$(helm home)" -xzv \
   ;

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -15,6 +15,7 @@ COPY --from=bats-image /usr/lib/bats-file /usr/lib/bats-file
 ARG HELM_CHART_VERSION
 ENV HELM_CHART_VERSION=${HELM_CHART_VERSION}
 
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN set -ex \
   #
   && apk add --update --no-cache \
@@ -23,6 +24,8 @@ RUN set -ex \
     coreutils=~8 \
   #
   && helm init --client-only \
-  && helm repo add socialgouv https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION} \
-  && wget -qO - https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz | tar -C $(helm home) -xzv \
+  && helm repo add socialgouv "https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}" \
+  && wget -qO - \
+    "https://github.com/SocialGouv/helm-charts/releases/download/v${HELM_CHART_VERSION}/helm-just-linux-${HELM_CHART_VERSION}.tgz" \
+    | tar -C "$(helm home)" -xzv \
   ;

--- a/helm/package.json
+++ b/helm/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "foo": "github:owner/foo#v12.13.45",
+    "bar": "github:owner/bar#v67.89.10"
+  }
+}

--- a/helm/package.json
+++ b/helm/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "foo": "github:owner/foo#v12.13.45",
-    "bar": "github:owner/bar#v67.89.10"
+    "@socialgouv/helm-charts": "github:SocialGouv/helm-charts#v5.0.0"
   }
 }


### PR DESCRIPTION
<img src=https://media.giphy.com/media/xThuWjDKlFhOVEyQN2/giphy.gif width=693>

---

To allow renovate to maintaining the socialgouv/docker/helm image we use a fake `package.json` that link to the repo we need to follow. The script below allow will build the version present in that file.