### PR TITLE
fix(k8s-ns-killer): uses socialgouv/docker/kubectl:1.14.0

### DIFF
--- a/k8s-ns-killer/Dockerfile
+++ b/k8s-ns-killer/Dockerfile
@@ -1,13 +1,16 @@
-FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/helm:0.29.0
+FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:1.14.0
 
 USER root
 
-RUN apk add --update --no-cache \
-  git=~2 \
-  less=~551 \
-  openssh=~8
+RUN set -ex \
+  #
+  && apk add --update --no-cache \
+    git=~2 \
+    less=~551 \
+    openssh=~8 \
+  ;
 
-USER kubectl
+USER 1001
 
 COPY ./bin /bin
 


### PR DESCRIPTION
<img src=https://media.giphy.com/media/l0Iy5jWZFjb60dBXa/giphy.gif width=693>