### PR TITLE
fix(k8s-object-cleaner): uses socialgouv/docker/kubectl:1.14.0

### DIFF
--- a/k8s-object-cleaner/Dockerfile
+++ b/k8s-object-cleaner/Dockerfile
@@ -1,14 +1,17 @@
-FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/helm:0.29.0
+FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:1.14.0
 
 USER root
 
-RUN apk add --update --no-cache \
-  git=~2 \
-  less=~551 \
-  openssh=~8 \
-  nodejs=~12
+RUN set -ex \
+  #
+  && apk add --update --no-cache \
+    git=~2 \
+    less=~551 \
+    openssh=~8 \
+    nodejs=~12 \
+  ;
 
-USER kubectl
+USER 1001
 
 COPY ./bin /bin
 


### PR DESCRIPTION
<img src=https://media.giphy.com/media/1KoN1DMBnCMWk/giphy.gif width=693>