### PR TITLE
fix(wait-for-postgres): remove pg_isready host wrapper

### DIFF
--- a/wait-for-postgres/bin/wait-for-postgres
+++ b/wait-for-postgres/bin/wait-for-postgres
@@ -12,7 +12,7 @@ wait_for_postgres() {
       echo "Waiting for Postgres to go Green ($(( retry )) left)" ;
       sleep "${interval}" ;
   done ;
-  is_postgres_ready
+  pg_isready
 }
 
 wait_for_postgres "$@"

--- a/wait-for-postgres/bin/wait-for-postgres
+++ b/wait-for-postgres/bin/wait-for-postgres
@@ -2,16 +2,11 @@
 
 {
 
-is_postgres_ready() {
-  local hostname=${PGHOST:-/run/postgresql};
-  pg_isready --host="${hostname}"
-}
-
 wait_for_postgres() {
   local retry=${WAIT_FOR_RETRIES:-24}; # = (2min x 60s) / 5s
   local interval=${WAIT_FOR_INTERVAL:-5s}; # every 5s
   while
-    ! is_postgres_ready  > /dev/null 2> /dev/null &&
+    ! pg_isready > /dev/null 2> /dev/null &&
     [[ $(( retry-- )) -gt 0 ]];
   do
       echo "Waiting for Postgres to go Green ($(( retry )) left)" ;


### PR DESCRIPTION
`pg_isready` accept regular PG env vars https://docs.postgresql.fr/11/libpq-envars.html