### PR TITLE
fix(nginx4spa): handle next.js static urls

### DIFF
--- a/nginx4spa/nginx.conf
+++ b/nginx4spa/nginx.conf
@@ -37,7 +37,8 @@ http {
     error_page              500 502 503 504  /50x.html;
 
     location / {
-      try_files $uri $uri/ /index.html;
+      # this always fallback on /index.html, never 404 
+      try_files $uri $uri/ $uri.html $uri/index.html /index.html;
     }
 
     location /50x.html {


### PR DESCRIPTION
When an url, ex : `/pros` is not found  :

 - try `/pros/`
 - try `/pros.html` <-- next.js
 - try `/pros/index.html`
 - fallback to `/index.html` for SPAs