### PR TITLE
feat(nginx)!: add nginx security headers to default config

### DIFF
--- a/nginx4spa/README.md
+++ b/nginx4spa/README.md
@@ -23,3 +23,14 @@ VERSION=x.y.z
 Notes:
 
 - `PORT` is optional and default to `80`
+
+To override default configuration, make a local copy of `nginx.conf` and add it to docker build:
+
+```dockerfile
+FROM ghcr.io/socialgouv/docker/nginx4spa:x.y.z
+
+COPY ./custom-nginx.conf /etc/nginx/nginx.conf
+COPY ./dist /usr/share/nginx/html
+```
+
+**Note**: follow security recommendations here: <https://socialgouv.github.io/support/#/securite>

--- a/nginx4spa/nginx.conf
+++ b/nginx4spa/nginx.conf
@@ -22,7 +22,10 @@ http {
     root                    /usr/share/nginx/html;
     index                   index.html;
     server_name_in_redirect on;
-
+    add_header X-Frame-Options "deny";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+    
     gzip on;
     gzip_disable "msie6";
     gzip_vary on;


### PR DESCRIPTION
BREAKING CHANGE: The following headers are added by default : 

```
add_header X-Frame-Options "deny";
add_header X-XSS-Protection "1; mode=block";
add_header X-Content-Type-Options "nosniff";
```