### PR TITLE
fix(wait-for-http): fix entrypoint

### DIFF
--- a/wait-for-http/Dockerfile
+++ b/wait-for-http/Dockerfile
@@ -5,4 +5,4 @@ COPY ./bin /bin
 ENV URL $URL
 ENV RETRIES $RETRIES
 
-ENTRYPOINT ["/bin/wait-for-http"]
+ENTRYPOINT ["sh", "/bin/wait-for-http"]

--- a/wait-for-http/tests/container-structure-test.yml
+++ b/wait-for-http/tests/container-structure-test.yml
@@ -1,5 +1,8 @@
 schemaVersion: "2.0.0"
 
+metadataTest:
+  entrypoint: ["sh", "/bin/wait-for-http"]
+
 commandTests:
   - name: "curl version"
     command: "curl"


### PR DESCRIPTION
fix:

```sh
➜ docker run --entrypoint /bin/wait-for-http ghcr.io/socialgouv/docker/wait-for-http:6.0.1  http://www.free.fr
standard_init_linux.go:219: exec user process caused: no such file or directory
```