### PR TITLE
fix(azure-db): dont update datallowconn

### DIFF
--- a/azure-db/bin/drop-db-user
+++ b/azure-db/bin/drop-db-user
@@ -28,10 +28,6 @@ echo "disconnect activities on database ${DROP_DATABASE} on ${PGHOST}"
 psql -abe "$PG_URL_ADMIN" -c "
   SET SESSION CHARACTERISTICS AS TRANSACTION READ WRITE;
 
-  -- Inspired by https://stackoverflow.com/questions/3185266/postgresql-temporarily-disable-connections
-  -- Temporarily disable connections
-  UPDATE pg_database SET datallowconn = false WHERE datname = '${DROP_DATABASE}';
-
   -- Disconnect users from database
   SELECT pg_terminate_backend (pg_stat_activity.pid)
   FROM pg_stat_activity


### PR DESCRIPTION
`UPDATE pg_database SET datallowconn = false WHERE...` throws `ERROR:  permission denied for relation pg_database` with an admin user...

The next line disconnects clients so i guess this is enough
