### PR TITLE
fix(nginx): static next.js friendly fallback

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,7 +43,13 @@ http {
 
     recursive_error_pages on;
 
+    location / {
+      # for next.js static exports, maps /page to page/index.html
+      try_files $uri $uri.html $uri/index.html =404;
+    }
+
     location ~* ^/404\.html$ {
+      # enable userland 404
       try_files /404.html /404/index.html
       error_page 404 = @error404;
     }


### PR DESCRIPTION
Adress an issue with next.js static routes and links

link to "/page" didnt matched "/page.html" when requested server-side