### PR TITLE
fix(nginx4spa): use upstream nginx image

### DIFF
--- a/nginx4spa/Dockerfile
+++ b/nginx4spa/Dockerfile
@@ -1,8 +1,18 @@
-FROM ghcr.io/socialgouv/docker/nginx:7.5@sha256:9ed92683c2d35db2c48068ef5a27559081184d04912cc3d1610fd00832f28cb5
-
-USER root
+FROM nginxinc/nginx-unprivileged:1.23-alpine@sha256:ae94ea43b80f95594498099feac9e70c8ad83916ccf923ed3de8e24cdda98ee1
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
+COPY ./entrypoint.sh /entrypoint.sh
+
+## adjust permissions
+USER root
+RUN chown -R nginx:nginx /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html && \
+        chown -R nginx:nginx /var/cache/nginx && \
+        chown -R nginx:nginx /var/log/nginx && \
+        chown -R nginx:nginx /etc/nginx
+
+RUN touch /var/run/nginx.pid && \
+        chown -R nginx:nginx /var/run/nginx.pid
 
 USER 101
 
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
use official upstream nginx image instead of reusing socialgouv nginx image